### PR TITLE
feat(get): Add GET /api/<team> and dummy JSON data

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,22 @@
+import time
 from flask import Flask, jsonify, request
 app = Flask(__name__, static_url_path='/static')
 
 @app.route('/')
 def home():
     return app.send_static_file('index.html')
+
+@app.route('/api/<team>')
+def get_scrum(team):
+    data = {
+            'team': team,
+            'created': int(time.time()),
+            'headers': {
+                'some_header': ['sticky1', 'sticky2'],
+                'another_one': ['test']
+                }
+            }
+    return jsonify(data)
 
 @app.route('/api')
 def hello_api():


### PR DESCRIPTION
## Context

Users will be able to get posted scrum board data. The API will expose an endpoint, `GET /api/<team>` that returns a JSON containing all the scrum board information for the specified team. For the sake of UI development, the endpoint will only return dummy data for now.

## Objective

* Add an endpoint, `GET /api/<team>`, that returns a JSON containing scrum board information
* Return dummy data when that endpoint is hit