### PR TITLE
feat(get endpoint): Implemented retrieving scrum data from MongoDB

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,14 +37,11 @@ def home():
 
 @app.route('/api/<team>')
 def get_scrum(team):
-    data = {
-            'team': team,
-            'created': int(time.time()),
-            'headers': {
-                'some_header': ['sticky1', 'sticky2'],
-                'another_one': ['test']
-                }
-            }
+    try:
+        data = mongo.db.boards.find({'team': team}).sort([('created', -1)]).next()
+        data.pop('_id', None)
+    except StopIteration:
+        data = {}
     return jsonify(data)
 
 @app.route('/api')


### PR DESCRIPTION
## Context
The get endpoint currently returns dummy data. We need to implement the method to actually query the real database.
Try `curl http://127.0.0.1:5000/api/cookies` for an example
## Objective
Implement the endpoint so that actual cached data is returned.
## References

## Lessons learned
Python iterators will throw an exception if there is nothing to iterate
PyMongo requires a list of tuples for sort, since python dictionaries are unordered.
Many MongoDB objects are unserializeable.